### PR TITLE
fix(package): fixing package name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"go-db-etl/pkg/config"
-	"go-db-etl/pkg/logging"
-	"go-db-etl/pkg/runner"
-	"go-db-etl/pkg/sources"
+	"gihub.com/ooemperor/go-db-etl/pkg/config"
+	"gihub.com/ooemperor/go-db-etl/pkg/logging"
+	"gihub.com/ooemperor/go-db-etl/pkg/runner"
+	"gihub.com/ooemperor/go-db-etl/pkg/sources"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-db-etl
+module gihub.com/ooemperor/go-db-etl
 
 go 1.24.0
 

--- a/pkg/config/Config.go
+++ b/pkg/config/Config.go
@@ -1,8 +1,8 @@
 package config
 
 import (
+	"gihub.com/ooemperor/go-db-etl/pkg/sources"
 	"github.com/joho/godotenv"
-	"go-db-etl/pkg/sources"
 	"os"
 	"strconv"
 )

--- a/pkg/pipeline/inb/SystemPackage.go
+++ b/pkg/pipeline/inb/SystemPackage.go
@@ -3,9 +3,9 @@ package inb
 import (
 	"database/sql"
 	"fmt"
+	"gihub.com/ooemperor/go-db-etl/pkg/logging"
+	"gihub.com/ooemperor/go-db-etl/pkg/sources"
 	"github.com/teambenny/goetl"
-	"go-db-etl/pkg/logging"
-	"go-db-etl/pkg/sources"
 )
 
 /*

--- a/pkg/pipeline/inb/TablePipelineBuilder.go
+++ b/pkg/pipeline/inb/TablePipelineBuilder.go
@@ -3,10 +3,10 @@ package inb
 import (
 	"database/sql"
 	"fmt"
+	"gihub.com/ooemperor/go-db-etl/pkg/logging"
+	"gihub.com/ooemperor/go-db-etl/pkg/sources"
 	"github.com/teambenny/goetl"
 	"github.com/teambenny/goetl/processors"
-	"go-db-etl/pkg/logging"
-	"go-db-etl/pkg/sources"
 )
 
 /*

--- a/pkg/runner/Runner.go
+++ b/pkg/runner/Runner.go
@@ -2,9 +2,9 @@ package runner
 
 import (
 	"fmt"
-	"go-db-etl/pkg/logging"
-	"go-db-etl/pkg/pipeline/inb"
-	"go-db-etl/pkg/sources"
+	"gihub.com/ooemperor/go-db-etl/pkg/logging"
+	"gihub.com/ooemperor/go-db-etl/pkg/pipeline/inb"
+	"gihub.com/ooemperor/go-db-etl/pkg/sources"
 )
 
 /*

--- a/pkg/sources/SourceConfig.go
+++ b/pkg/sources/SourceConfig.go
@@ -3,7 +3,7 @@ package sources
 import (
 	"encoding/json"
 	"fmt"
-	"go-db-etl/pkg/logging"
+	"gihub.com/ooemperor/go-db-etl/pkg/logging"
 	"os"
 )
 


### PR DESCRIPTION
This pull request updates the module path and import statements across the codebase to reflect a new repository location. The changes ensure consistency and correctness in referencing the updated module path.

### Module Path Update:

* Updated the module path in `go.mod` to `gihub.com/ooemperor/go-db-etl` to reflect the new repository location.

### Import Statement Adjustments:

* Updated import paths in `cmd/main.go` to use the new module path `gihub.com/ooemperor/go-db-etl`.
* Updated import paths in `pkg/config/Config.go` to reference the new module path.
* Updated import paths in `pkg/pipeline/inb/SystemPackage.go` and `pkg/pipeline/inb/TablePipelineBuilder.go` to use the new module path. [[1]](diffhunk://#diff-3e36168b9a82299e906dc86c378b7e363298691f94c8fbc9cd80a6ab89aac1caR6-L8) [[2]](diffhunk://#diff-e099f11a42cb11ef9f845e413bc13efcef4c61850be49b26c8327fe30cfb14b0R6-L9)
* Updated import paths in `pkg/runner/Runner.go` and `pkg/sources/SourceConfig.go` to reflect the new module path. [[1]](diffhunk://#diff-699eb37934b0174c27970f7eed4a297053e608fc7e24b5c27f76b8a47f191104L5-R7) [[2]](diffhunk://#diff-1491666a3ca6f77d81c1b90c6bd3575d7a1294da95a634bded430b0cc6916eadL6-R6)