### PR TITLE
fix(package): fixing package name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"gihub.com/ooemperor/go-db-etl/pkg/config"
-	"gihub.com/ooemperor/go-db-etl/pkg/logging"
-	"gihub.com/ooemperor/go-db-etl/pkg/runner"
-	"gihub.com/ooemperor/go-db-etl/pkg/sources"
+	"github.com/ooemperor/go-db-etl/pkg/config"
+	"github.com/ooemperor/go-db-etl/pkg/logging"
+	"github.com/ooemperor/go-db-etl/pkg/runner"
+	"github.com/ooemperor/go-db-etl/pkg/sources"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gihub.com/ooemperor/go-db-etl
+module github.com/ooemperor/go-db-etl
 
 go 1.24.0
 

--- a/pkg/config/Config.go
+++ b/pkg/config/Config.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-	"gihub.com/ooemperor/go-db-etl/pkg/sources"
 	"github.com/joho/godotenv"
+	"github.com/ooemperor/go-db-etl/pkg/sources"
 	"os"
 	"strconv"
 )

--- a/pkg/pipeline/inb/SystemPackage.go
+++ b/pkg/pipeline/inb/SystemPackage.go
@@ -3,8 +3,8 @@ package inb
 import (
 	"database/sql"
 	"fmt"
-	"gihub.com/ooemperor/go-db-etl/pkg/logging"
-	"gihub.com/ooemperor/go-db-etl/pkg/sources"
+	"github.com/ooemperor/go-db-etl/pkg/logging"
+	"github.com/ooemperor/go-db-etl/pkg/sources"
 	"github.com/teambenny/goetl"
 )
 

--- a/pkg/pipeline/inb/TablePipelineBuilder.go
+++ b/pkg/pipeline/inb/TablePipelineBuilder.go
@@ -3,8 +3,8 @@ package inb
 import (
 	"database/sql"
 	"fmt"
-	"gihub.com/ooemperor/go-db-etl/pkg/logging"
-	"gihub.com/ooemperor/go-db-etl/pkg/sources"
+	"github.com/ooemperor/go-db-etl/pkg/logging"
+	"github.com/ooemperor/go-db-etl/pkg/sources"
 	"github.com/teambenny/goetl"
 	"github.com/teambenny/goetl/processors"
 )

--- a/pkg/runner/Runner.go
+++ b/pkg/runner/Runner.go
@@ -2,9 +2,9 @@ package runner
 
 import (
 	"fmt"
-	"gihub.com/ooemperor/go-db-etl/pkg/logging"
-	"gihub.com/ooemperor/go-db-etl/pkg/pipeline/inb"
-	"gihub.com/ooemperor/go-db-etl/pkg/sources"
+	"github.com/ooemperor/go-db-etl/pkg/logging"
+	"github.com/ooemperor/go-db-etl/pkg/pipeline/inb"
+	"github.com/ooemperor/go-db-etl/pkg/sources"
 )
 
 /*

--- a/pkg/sources/SourceConfig.go
+++ b/pkg/sources/SourceConfig.go
@@ -3,7 +3,7 @@ package sources
 import (
 	"encoding/json"
 	"fmt"
-	"gihub.com/ooemperor/go-db-etl/pkg/logging"
+	"github.com/ooemperor/go-db-etl/pkg/logging"
 	"os"
 )
 


### PR DESCRIPTION
This pull request fixes a recurring typo in the import paths across multiple files, changing `gihub.com` to `github.com` to ensure compatibility and correctness. Additionally, it updates the module path in the `go.mod` file to reflect the corrected import path.

### Fixes to import paths:

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L4-R7): Corrected import paths from `gihub.com` to `github.com` for multiple packages.
* [`pkg/config/Config.go`](diffhunk://#diff-57d41133613f8e4793f78f04863a3242710c0cb30111a5fd391f59d77cea33bcL4-R5): Updated the import path for `sources` to use `github.com` instead of `gihub.com`.
* [`pkg/pipeline/inb/SystemPackage.go`](diffhunk://#diff-3e36168b9a82299e906dc86c378b7e363298691f94c8fbc9cd80a6ab89aac1caL6-R7): Fixed import paths for `logging` and `sources` to use `github.com`.
* [`pkg/pipeline/inb/TablePipelineBuilder.go`](diffhunk://#diff-e099f11a42cb11ef9f845e413bc13efcef4c61850be49b26c8327fe30cfb14b0L6-R7): Corrected import paths for `logging` and `sources` to use `github.com`.
* [`pkg/runner/Runner.go`](diffhunk://#diff-699eb37934b0174c27970f7eed4a297053e608fc7e24b5c27f76b8a47f191104L5-R7): Updated import paths for `logging`, `pipeline/inb`, and `sources` to use `github.com`.
* [`pkg/sources/SourceConfig.go`](diffhunk://#diff-1491666a3ca6f77d81c1b90c6bd3575d7a1294da95a634bded430b0cc6916eadL6-R6): Fixed the import path for `logging` to use `github.com`.

### Update to module path:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1): Changed the module declaration from `gihub.com/ooemperor/go-db-etl` to `github.com/ooemperor/go-db-etl` to align with the corrected import paths.