### PR TITLE
feat(batchsize): adding hardcoded batchsizes to the load procedures

### DIFF
--- a/pkg/pipeline/inb/TablePipelineBuilder.go
+++ b/pkg/pipeline/inb/TablePipelineBuilder.go
@@ -29,7 +29,9 @@ func (inb *SrcTablePipelineBuilder) Build() *goetl.Pipeline {
 	truncator := processors.NewSQLExecutor(inb.targetDb, truncateQuery)
 
 	reader := processors.NewSQLReader(inb.sourceDb, queryString)
+	reader.BatchSize = -1
 	writer := processors.NewPostgreSQLWriter(inb.targetDb, destinationTable)
+	writer.BatchSize = 1000
 	writer.OnDupKeyUpdate = false
 
 	truncateAndReadStage := goetl.NewPipelineStage(goetl.Do(truncator).Outputs(writer), goetl.Do(reader).Outputs(writer))


### PR DESCRIPTION
This pull request makes adjustments to the `SrcTablePipelineBuilder` in the `TablePipelineBuilder.go` file to configure batch sizes for the SQL reader and PostgreSQL writer, optimizing data processing behavior.

### Configuration changes for data processing:

* [`pkg/pipeline/inb/TablePipelineBuilder.go`](diffhunk://#diff-e099f11a42cb11ef9f845e413bc13efcef4c61850be49b26c8327fe30cfb14b0R32-R34): Set `reader.BatchSize` to `-1`, which likely disables batching for the SQL reader.
* [`pkg/pipeline/inb/TablePipelineBuilder.go`](diffhunk://#diff-e099f11a42cb11ef9f845e413bc13efcef4c61850be49b26c8327fe30cfb14b0R32-R34): Set `writer.BatchSize` to `1000`, enabling batching for the PostgreSQL writer with a batch size of 1000 rows.