### PR TITLE
Development

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 CGO_enabled=1
 timeout_sec=10
 name=go-db-etl
+batch_size_read=10000
+batch_size_writer=1000

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  runner:
+    image: ghcr.io/ooemperor/go-db-etl:latest
+    container_name: go-db-etl
+    volumes:
+      - "../src.test.json:/app/src.test.json"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/joho/godotenv v1.5.1
+	github.com/lib/pq v1.10.9
 	github.com/microsoft/go-mssqldb v1.8.0
 	github.com/teambenny/goetl v1.0.9
 )
@@ -29,7 +30,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kisielk/sqlstruct v0.0.0-20210630145711-dae28ed37023 // indirect
 	github.com/kr/fs v0.1.0 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.13.5 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/pkg/config/Config.go
+++ b/pkg/config/Config.go
@@ -1,19 +1,22 @@
 package config
 
 import (
-	"github.com/joho/godotenv"
-	"github.com/ooemperor/go-db-etl/pkg/sources"
 	"os"
 	"strconv"
+
+	"github.com/joho/godotenv"
+	"github.com/ooemperor/go-db-etl/pkg/sources"
 )
 
 /*
 Configuration Object that holds all the necessary config information
 */
 type Configuration struct {
-	postgresHost string
-	timeout      int64
-	Name         string
+	postgresHost    string
+	timeout         int64
+	Name            string
+	BatchSizeReader int
+	BatchSizeWriter int
 }
 
 /*
@@ -27,6 +30,11 @@ func (conf *Configuration) Init(envFile string) (*Configuration, error) {
 
 	conf.timeout, _ = strconv.ParseInt(os.Getenv("timeout_sec"), 10, 64)
 	conf.Name = os.Getenv("name")
+	var batchReader, _ = strconv.ParseInt(os.Getenv("batch_size_read"), 10, 64)
+	var batchWriter, _ = strconv.ParseInt(os.Getenv("batch_size_writer"), 10, 64)
+
+	conf.BatchSizeReader = int(batchReader)
+	conf.BatchSizeWriter = int(batchWriter)
 
 	return conf, nil
 }

--- a/pkg/pipeline/srcinb/TablePipelineBuilder.go
+++ b/pkg/pipeline/srcinb/TablePipelineBuilder.go
@@ -3,6 +3,8 @@ package srcinb
 import (
 	"database/sql"
 	"fmt"
+
+	"github.com/ooemperor/go-db-etl/pkg/config"
 	"github.com/ooemperor/go-db-etl/pkg/logging"
 	"github.com/ooemperor/go-db-etl/pkg/sources"
 	"github.com/teambenny/goetl"
@@ -29,9 +31,9 @@ func (inb *SrcTablePipelineBuilder) Build() *goetl.Pipeline {
 	truncator := processors.NewSQLExecutor(inb.TargetDb, truncateQuery)
 
 	reader := processors.NewSQLReader(inb.SourceDb, queryString)
-	reader.BatchSize = -1
+	reader.BatchSize = config.Config.BatchSizeReader
 	writer := processors.NewPostgreSQLWriter(inb.TargetDb, destinationTable)
-	writer.BatchSize = 1000
+	writer.BatchSize = config.Config.BatchSizeWriter
 	writer.OnDupKeyUpdate = false
 
 	truncateAndReadStage := goetl.NewPipelineStage(goetl.Do(truncator).Outputs(writer), goetl.Do(reader).Outputs(writer))


### PR DESCRIPTION
This pull request introduces configurable batch sizes for reading and writing operations in the ETL pipeline and updates the Docker Compose setup to include a runner service. The changes enhance the flexibility of the pipeline and improve deployment options.

**Configuration enhancements:**

* Added `batch_size_read` and `batch_size_writer` environment variables to `.env` and mapped them to new fields `BatchSizeReader` and `BatchSizeWriter` in the `Configuration` struct (`pkg/config/Config.go`). These values are now loaded during configuration initialization. [[1]](diffhunk://#diff-e9cbb0224c4a3d23a6019ba557e0cd568c1ad5e1582ff1e335fb7d99b7a1055dR4-R5) [[2]](diffhunk://#diff-57d41133613f8e4793f78f04863a3242710c0cb30111a5fd391f59d77cea33bcR18-R19) [[3]](diffhunk://#diff-57d41133613f8e4793f78f04863a3242710c0cb30111a5fd391f59d77cea33bcR33-R37)
* Updated the pipeline builder to use the batch size values from the configuration for the SQL reader and PostgreSQL writer, replacing hardcoded values.

**Deployment improvements:**

* Added a `runner` service to `build/docker-compose.yml` to facilitate containerized execution of the ETL process.

**Dependency updates:**

* Added `github.com/lib/pq` as a direct dependency in `go.mod` and removed its indirect reference. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R8) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L32)

**Code organization:**

* Minor import order cleanup in `pkg/config/Config.go` for improved readability. [[1]](diffhunk://#diff-57d41133613f8e4793f78f04863a3242710c0cb30111a5fd391f59d77cea33bcL4-R8) [[2]](diffhunk://#diff-b374c87e9607a2866376879ee396cb32c38eb05528e6aac15ef5ebbd3d0a3cf0R6-R7)