### PR TITLE
fix(workflows): introduce tags workflow and fix spelling dev workflow

### DIFF
--- a/.github/workflows/docker_build_publish_tags.yml
+++ b/.github/workflows/docker_build_publish_tags.yml
@@ -7,9 +7,7 @@ name: Docker build and push on development branch
 
 on:
   push:
-    branches: [ "development"]
-  pull_request:
-    branches: [ "development"]
+    tags: [ "v*"]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -64,9 +62,6 @@ jobs:
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
-            type=raw,value=development,priority=1,enable=${{ github.event.inputs.tag == '' }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and publishing Docker images when tags matching the pattern `v*` are pushed, and also corrects a typo in an existing workflow. The main focus is on automating Docker image builds and signing for tagged releases.

New workflow for tagged Docker builds and signing:

* Added `.github/workflows/docker_build_publish_tags.yml` to automate Docker image build, push, and signing when a tag is pushed. This includes steps for checking out the repository, installing cosign, setting up Docker Buildx, logging into the registry, extracting Docker metadata, building and pushing the image, and signing the image digest.

Bug fix in Docker build workflow:

* Fixed a typo in the `tags` section of `.github/workflows/docker_build_publish_development.yml` (`tpye` → `type`).